### PR TITLE
Fix unauthorized GraphQL mutations

### DIFF
--- a/client/src/pages/Profile.tsx
+++ b/client/src/pages/Profile.tsx
@@ -56,6 +56,7 @@ const Profile: React.FC = () => {
 
         try {
             await client.graphql({
+                authMode: 'AMAZON_COGNITO_USER_POOLS',
                 query: createProfile,
                 variables: {
                     input: {
@@ -70,6 +71,7 @@ const Profile: React.FC = () => {
             if (msg.includes('already exists') || msg.includes('Conflict')) {
                 try {
                     await client.graphql({
+                        authMode: 'AMAZON_COGNITO_USER_POOLS',
                         query: updateProfile,
                         variables: { input },
                     });
@@ -89,6 +91,7 @@ const Profile: React.FC = () => {
         const fetchOrInitProfile = async () => {
             try {
                 await client.graphql({
+                    authMode: 'AMAZON_COGNITO_USER_POOLS',
                     query: createProfile,
                     variables: {
                         input: {


### PR DESCRIPTION
## Summary
- force the GraphQL client to use Cognito user pool authorization when creating and updating profiles

## Testing
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68459a40d0a083259201fb3c6876d1b3